### PR TITLE
멤버 서비스 - MemberInfoController uri 수정

### DIFF
--- a/dtk-member-api/src/main/java/com/devtalk/member/memberservice/member/adapter/in/web/MemberInfoController.java
+++ b/dtk-member-api/src/main/java/com/devtalk/member/memberservice/member/adapter/in/web/MemberInfoController.java
@@ -14,12 +14,12 @@ import org.springframework.web.bind.annotation.RestController;
 public class MemberInfoController {
     private final MemberInfoUseCase memberInfoUseCase;
 
-    @GetMapping("/member/{consultant}/info")
+    @GetMapping("/member/profile/consultant/{consultant}/info")
     MemberRes.ConsultantRes getConsultantInfo(@PathVariable Long consultant) {
         return memberInfoUseCase.findConsultant(consultant);
     }
 
-    @GetMapping("/member/{consulter}/info")
+    @GetMapping("/member/profile/consulter/{consulter}/info")
     MemberRes.ConsulterRes getConsulterInfo(@PathVariable Long consulter) {
         return memberInfoUseCase.findConsulter(consulter);
     }


### PR DESCRIPTION
- /member/** uri는 인증이 필요하기 때문에 /member/profile/**(인증 X)로 수정
- 현재 consultant, consulter uri가 동일하던 것들을 /member/profile/consultant/**, /member/profile/consulter/**로 구분